### PR TITLE
fix: align default example README and example

### DIFF
--- a/examples/default-config/README.md
+++ b/examples/default-config/README.md
@@ -7,6 +7,7 @@ module "lacework_oci_cfg_integration" {
   source = "lacework/config/oci"
   create = true
   tenancy_id = var.tenancy_ocid
+  user_email = "example@example.com"
 }
 
 variable "tenancy_ocid" {

--- a/examples/default-config/main.tf
+++ b/examples/default-config/main.tf
@@ -1,5 +1,5 @@
 module "lacework_oci_cfg_integration" {
-  source     = "../.."
+  source = "lacework/config/oci"
   create     = true
   tenancy_id = var.tenancy_ocid
   user_email = "example@example.com"

--- a/examples/default-config/main.tf
+++ b/examples/default-config/main.tf
@@ -1,5 +1,5 @@
 module "lacework_oci_cfg_integration" {
-  source = "lacework/config/oci"
+  source     = "../.."
   create     = true
   tenancy_id = var.tenancy_ocid
   user_email = "example@example.com"


### PR DESCRIPTION
Include user_email in README

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

Small fix to default doc.

## How did you test this change?

Ran terraform in OCI cloudshell with main.ft file