### PR TITLE
docs: add a note about OCI eventual consistency issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@
 A Terraform Module for configuring a CSPM integration with Lacework for an OCI cloud
 account.
 
+## Troubleshooting
+
+Sometimes it takes a moment for OCI resources to become available after they've been created.
+When that happens, this module will sometimes fail `terraform apply`. Rerunning `terraform
+apply` will solve it, since by then the created OCI resources will have become available.
+
 ## Requirements
 
 | Name | Version |


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

Add a note about how OCI eventual consistency sometimes causes resources not to be available right away, leading to `terraform apply` failures.

## How did you test this change?

N/A

## Issue

None