### PR TITLE
feat(SPM-1806): add random string to resources to avoid collissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ apply` will solve it, since by then the created OCI resources will have become a
 |------|---------|
 | <a name="provider_lacework"></a> [lacework](#provider\_lacework) | >= 1.9.0 |
 | <a name="provider_oci"></a> [oci](#provider\_oci) | >= 5.2.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
 | <a name="provider_time"></a> [time](#provider\_time) | ~> 0.9 |
 
 ## Modules
@@ -43,6 +44,7 @@ apply` will solve it, since by then the created OCI resources will have become a
 |------|------|
 | [lacework_integration_oci_cfg.lacework_integration](https://registry.terraform.io/providers/lacework/lacework/latest/docs/resources/integration_oci_cfg) | resource |
 | [oci_identity_policy.lacework_policy](https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/identity_policy) | resource |
+| [random_id.uniq](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [time_sleep.wait_time](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [oci_identity_region_subscriptions.home_region](https://registry.terraform.io/providers/oracle/oci/latest/docs/data-sources/identity_region_subscriptions) | data source |
 | [oci_identity_tenancy.tenancy](https://registry.terraform.io/providers/oracle/oci/latest/docs/data-sources/identity_tenancy) | data source |
@@ -55,7 +57,7 @@ apply` will solve it, since by then the created OCI resources will have become a
 | <a name="input_freeform_tags"></a> [freeform\_tags](#input\_freeform\_tags) | freeform tags for the resources created for Lacework CSPM integration | `map(any)` | `{}` | no |
 | <a name="input_group_name"></a> [group\_name](#input\_group\_name) | Name of the IAM group for the Lacework user (overrides name\_prefix) | `string` | `""` | no |
 | <a name="input_integration_name"></a> [integration\_name](#input\_integration\_name) | Label for the OCI integration used within the Lacework platform | `string` | `"OCI CSPM Integration"` | no |
-| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | The OCI resources will have the names ${name\_prefix}\_{user,group,policy} | `string` | `"lacework_cspm_integration"` | no |
+| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | The OCI resources will have the names ${name\_prefix}\_{user,group,policy} | `string` | `"lw_cspm"` | no |
 | <a name="input_policy_name"></a> [policy\_name](#input\_policy\_name) | Name of the policy that governs the Lacework user's permissions (overrides name\_prefix) | `string` | `""` | no |
 | <a name="input_tenancy_id"></a> [tenancy\_id](#input\_tenancy\_id) | OCID of the OCI tenancy to be integrated with Lacework | `string` | n/a | yes |
 | <a name="input_user_email"></a> [user\_email](#input\_user\_email) | Email associated with the created user | `string` | n/a | yes |

--- a/examples/default-config/README.md
+++ b/examples/default-config/README.md
@@ -1,6 +1,12 @@
 # Default Example
 
 This is an example of using the Terraform module for Lacework CSPM integration.
+You need to provide credentials to the OCI provider and the Lacework provider.
+If you already have your OCI and Lacework CLI tools installed and configured,
+the providers will be able to access the same credentials as those CLI tools.
+Otherwise, see the [Lacework provider docs](https://registry.terraform.io/providers/lacework/lacework/latest/docs)
+and the [OCI provider docs](https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/terraformproviderconfiguration.htm)
+for a list of options of how to provide credentials to those providers.
 
 ```hcl
 module "lacework_oci_cfg_integration" {

--- a/examples/default-config/main.tf
+++ b/examples/default-config/main.tf
@@ -2,9 +2,14 @@ module "lacework_oci_cfg_integration" {
   source     = "../.."
   create     = true
   tenancy_id = var.tenancy_ocid
-  user_email = "example@example.com"
+  user_email = var.user_email
 }
 
 variable "tenancy_ocid" {
   type = string
+}
+
+variable "user_email" {
+	type = string
+	default = "example@example.com"
 }

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,11 @@
 locals {
-  policy_name = length(var.policy_name) > 0 ? var.policy_name : "${var.name_prefix}_policy"
+  policy_name = length(var.policy_name) > 0 ? var.policy_name : "${var.name_prefix}_policy_${random_id.uniq.hex}"
+  user_name = length(var.user_name) > 0 ? var.user_name : "${var.name_prefix}_user_${random_id.uniq.hex}"
+  group_name = length(var.group_name) > 0 ? var.group_name : "${var.name_prefix}_group_${random_id.uniq.hex}"
+}
+
+resource "random_id" "uniq" {
+  byte_length = 4
 }
 
 module "lacework_oci_credentials" {
@@ -10,8 +16,8 @@ module "lacework_oci_credentials" {
   freeform_tags = var.freeform_tags
   email         = var.user_email
   name_prefix   = var.name_prefix
-  user_name     = var.user_name
-  group_name    = var.group_name
+  user_name     = local.user_name
+  group_name    = local.group_name
 }
 
 resource "oci_identity_policy" "lacework_policy" {
@@ -21,31 +27,30 @@ resource "oci_identity_policy" "lacework_policy" {
   name           = local.policy_name
   freeform_tags  = var.freeform_tags
   statements = [
+    # Keep alphabetical order to avoid duplicates
     "Allow group '${module.lacework_oci_credentials.group_name}' to inspect compartments in tenancy",
-    "Allow group '${module.lacework_oci_credentials.group_name}' to read buckets in tenancy",
-    "Allow group '${module.lacework_oci_credentials.group_name}' to inspect volumes in tenancy",
-    "Allow group '${module.lacework_oci_credentials.group_name}' to inspect security-lists in tenancy",
-    "Allow group '${module.lacework_oci_credentials.group_name}' to read users in tenancy",
-    "Allow group '${module.lacework_oci_credentials.group_name}' to inspect groups in tenancy",
-    "Allow group '${module.lacework_oci_credentials.group_name}' to inspect policies in tenancy",
     "Allow group '${module.lacework_oci_credentials.group_name}' to inspect domains in tenancy",
-    "Allow group '${module.lacework_oci_credentials.group_name}' to inspect tag-defaults in tenancy",
-    "Allow group '${module.lacework_oci_credentials.group_name}' to read instances in tenancy",
-    "Allow group '${module.lacework_oci_credentials.group_name}' to inspect subnets in tenancy",
-    "Allow group '${module.lacework_oci_credentials.group_name}' to read network-security-groups in tenancy",
-    "Allow group '${module.lacework_oci_credentials.group_name}' to inspect policies in tenancy",
-    "Allow group '${module.lacework_oci_credentials.group_name}' to inspect tenancies in tenancy",
-    "Allow group '${module.lacework_oci_credentials.group_name}' to inspect subnets in tenancy",
-    "Allow group '${module.lacework_oci_credentials.group_name}' to inspect route-tables in tenancy",
-    "Allow group '${module.lacework_oci_credentials.group_name}' to inspect internet-gateways in tenancy",
-    "Allow group '${module.lacework_oci_credentials.group_name}' to inspect load-balancers in tenancy",
-    "Allow group '${module.lacework_oci_credentials.group_name}' to read compute-clusters in tenancy",
+    "Allow group '${module.lacework_oci_credentials.group_name}' to inspect groups in tenancy",
     "Allow group '${module.lacework_oci_credentials.group_name}' to inspect instance-images in tenancy",
-    "Allow group '${module.lacework_oci_credentials.group_name}' to inspect vnic-attachments in tenancy",
-    "Allow group '${module.lacework_oci_credentials.group_name}' to inspect volume-attachments in tenancy",
-    "Allow group '${module.lacework_oci_credentials.group_name}' to inspect vcns in tenancy",
+    "Allow group '${module.lacework_oci_credentials.group_name}' to inspect internet-gateways in tenancy",
     "Allow group '${module.lacework_oci_credentials.group_name}' to inspect leaf-certificates in tenancy",
-    "Allow group '${module.lacework_oci_credentials.group_name}' to inspect vnics in tenancy"
+    "Allow group '${module.lacework_oci_credentials.group_name}' to inspect load-balancers in tenancy",
+    "Allow group '${module.lacework_oci_credentials.group_name}' to inspect policies in tenancy",
+    "Allow group '${module.lacework_oci_credentials.group_name}' to inspect route-tables in tenancy",
+    "Allow group '${module.lacework_oci_credentials.group_name}' to inspect security-lists in tenancy",
+    "Allow group '${module.lacework_oci_credentials.group_name}' to inspect subnets in tenancy",
+    "Allow group '${module.lacework_oci_credentials.group_name}' to inspect tag-defaults in tenancy",
+    "Allow group '${module.lacework_oci_credentials.group_name}' to inspect tenancies in tenancy",
+    "Allow group '${module.lacework_oci_credentials.group_name}' to inspect vcns in tenancy",
+    "Allow group '${module.lacework_oci_credentials.group_name}' to inspect vnic-attachments in tenancy",
+    "Allow group '${module.lacework_oci_credentials.group_name}' to inspect vnics in tenancy",
+    "Allow group '${module.lacework_oci_credentials.group_name}' to inspect volume-attachments in tenancy",
+    "Allow group '${module.lacework_oci_credentials.group_name}' to inspect volumes in tenancy",
+    "Allow group '${module.lacework_oci_credentials.group_name}' to read buckets in tenancy",
+    "Allow group '${module.lacework_oci_credentials.group_name}' to read compute-clusters in tenancy",
+    "Allow group '${module.lacework_oci_credentials.group_name}' to read instances in tenancy",
+    "Allow group '${module.lacework_oci_credentials.group_name}' to read network-security-groups in tenancy",
+    "Allow group '${module.lacework_oci_credentials.group_name}' to read users in tenancy"
   ]
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -26,7 +26,7 @@ variable "freeform_tags" {
 
 variable "name_prefix" {
   type        = string
-  default     = "lacework_cspm_integration"
+  default     = "lw_cspm"
   description = "The OCI resources will have the names $${name_prefix}_{user,group,policy}"
 }
 


### PR DESCRIPTION
## Summary

This change adds a random string at the end of created resources. E.g. the created OCI user will be called `lw_cspm_user_1ab3f2` instead of `lw_cspm_user`. This helps prevent the TF module from trying to create resources with names that already exist. The OCI Terraform Provider is not great at handling those errors. 


## How did you test this change?

I ran the TF code in this module to integrate an OCI account into a dev Lacework environment:

```
cd examples/default-config
tf init
tf plan -var tenancy_ocid=<tenancy ocid> -var user_email=<my email>
tf apply -var tenancy_ocid=<tenancy ocid> -var user_email=<my email>
```

which reported success/
<img width="923" alt="Screenshot 2023-10-31 at 11 37 12 AM" src="https://github.com/lacework/terraform-oci-config/assets/10789086/01c5bb44-6a3a-40a0-8ea8-cb09e0d6380c">

I also verified that the integration was created by running `lacework cloud-account list` and checking to make sure my integration was listed. Then I cleaned up:

```
tf destroy  -var tenancy_ocid=<tenancy ocid> -var user_email=<my email>
```


## Issue

SPM-1806